### PR TITLE
Add DISTINCT in class-utils.php

### DIFF
--- a/includes/class-utils.php
+++ b/includes/class-utils.php
@@ -135,7 +135,7 @@ class Utils {
 
 		$not_in = self::prepare_in( $black_list );
 
-		$sql = "SELECT meta_key
+		$sql = "SELECT DISTINCT meta_key
 				FROM {$wpdb->postmeta}
 				WHERE SUBSTRING(meta_key, 1, 7) NOT IN ({$not_in})
 				ORDER BY meta_key


### PR DESCRIPTION
DISTINCT was added to reduce the sampling of rows from the database on sites with a large number of post_metas, which caused the mysqld command to fill the disk up to 100%.

Tested for 48 hours with this supplement - everything is fine.